### PR TITLE
set scarfSettings.allowTopLevel to track hyp-cli install through curl

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "watch": "rm -rf dist && tsc -b -w",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "npm i && npm run build && oclif manifest"
+  },
+  "scarfSettings": {
+    "allowTopLevel": true
   }
 }


### PR DESCRIPTION
**Description**

set `scarfSettings.allowTopLevel` to track `hyp-cli` install through `curl`

See https://docs.scarf.sh/package-analytics/#configuration
Basically, we install the CLI into a global folder instead of doing `npm i -g`, so this install will not trigger scarf.
Caveat: When someone is setting up CLI dev locally for first time, `npm i` will trigger one install count. This install will be cached and subsequent `npm i` won't trigger it.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [x] For new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs) staged and linked here
