### PR TITLE
fix link flow when unlinked project exists

### DIFF
--- a/src/commands/link/index.ts
+++ b/src/commands/link/index.ts
@@ -15,7 +15,7 @@ import { URL } from "node:url";
 import open from "open";
 
 import { ciStr } from "../../util/ci.js";
-import { getProjectsByOrgReq, sendCreateProjectRepoReq, sendCreateProjectReq, sendGetRepoIdReq } from "../../util/graphql.js";
+import { getProjectsByOrgReq, sendMapRepoAndFinishProjectCreationReq, sendCreateProjectReq, sendGetRepoIdReq } from "../../util/graphql.js";
 import { confirmExistingProjectLink, confirmOverwriteCiHypFile, fileExists, getCiHypFilePath, getSettingsFilePath, getGitConfigFilePath, getGitRemoteUrl, getGithubWorkflowDir, promptProjectLinkSelection, promptProjectName, readSettingsJson, writeGithubInstallationIdToSettingsFile } from "../../util/index.js";
 
 export default class LinkIndex extends Command {
@@ -160,7 +160,7 @@ export default class LinkIndex extends Command {
 
       if (confirmExistingProject) {
         selectedProject = await promptProjectLinkSelection(projectsNoRepoId);
-        const completedProject = await sendCreateProjectRepoReq(settings.jwt, selectedProject.id, repoId, repoFullName);
+        const completedProject = await sendMapRepoAndFinishProjectCreationReq(settings.jwt, selectedProject.id, repoId, repoFullName);
 
         this.log(chalk.green("Successfully linked project " + completedProject.name + " to repo " + repoName + "! 🎉"));
       } else {

--- a/src/util/graphql.ts
+++ b/src/util/graphql.ts
@@ -28,10 +28,10 @@ export async function sendGraphQLReqToHypermode(jwt: string, query: string): Pro
   return data;
 }
 
-export async function sendCreateProjectRepoReq(jwt: string, id: string, repoId: string, repoName: string): Promise<Project> {
+export async function sendMapRepoAndFinishProjectCreationReq(jwt: string, id: string, repoId: string, repoName: string): Promise<Project> {
   const query = `
-    mutation CreateProjectRepo {
-      createProjectRepo(input: {id: "${id}", repoName: "${repoName}", repoId: "${repoId}", sourceType: CUSTOM}) {
+    mutation MapRepoAndFinishProjectCreation {
+      mapRepoAndFinishProjectCreation(input: {id: "${id}", repoName: "${repoName}", repoId: "${repoId}", sourceType: CUSTOM, defaultBranchName: "main"}) {
           id
           name
           repoId
@@ -40,7 +40,7 @@ export async function sendCreateProjectRepoReq(jwt: string, id: string, repoId: 
 
   const data: any = await sendGraphQLReqToHypermode(jwt, query);
 
-  const project: Project = data.data.createProjectRepo;
+  const project: Project = data.data.mapRepoAndFinishProjectCreation;
 
   return project;
 }


### PR DESCRIPTION
**Description**

We have to use the finishprojectcreation api when the user has an unlinked project flow.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] For new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs) staged and linked here
