### PR TITLE
Fix: `hyp login` failing with `EONET`

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -151,6 +151,16 @@ export async function readSettingsJson(filePath: string): Promise<{
   apiKey: null | string
   workspaceId: null | string
 }> {
+  if (!(await fileExists(filePath))) {
+    return {
+      content: '',
+      email: null,
+      installationIds: null,
+      apiKey: null,
+      workspaceId: null,
+    }
+  }
+
   const content = await fs.readFile(filePath, 'utf8')
 
   let email: null | string = null


### PR DESCRIPTION
When doing a fresh global install of `@hypermode/hyp-cli` and then running `hyp login`, the command fails because it tries to read/write to `.hypermode/settings.json` assuming it exists.

All this PR does is makes sure that the `settings.json` exists
